### PR TITLE
Add CTA bar to Podcast page

### DIFF
--- a/_includes/blocks/cta_bar.liquid
+++ b/_includes/blocks/cta_bar.liquid
@@ -3,7 +3,13 @@
     <div class="container">
         <div class="row align-items-center">
             <div class="col-lg-4">
-                <h2 class="unusable__highlight-text">Subscribe now</h2>
+                <h2 class="unusable__highlight-text">
+                    {% if cta-title %}
+                        {{ cta-title }}
+                    {% else %}
+                        Subscribe now
+                    {% endif %}
+                </h2>
             </div>
             {% assign firstFourPlatforms = platforms | limit:4 %}
             {% for platform in firstFourPlatforms %}

--- a/_includes/podcast.liquid
+++ b/_includes/podcast.liquid
@@ -10,6 +10,7 @@
     {% assign episodeNumber = "Episode " | append: number  %}
     {% assign image = "podcasts/" | append:number | append:".jpg" %}
     {% include blocks/header.liquid, dark: true, subtitle: episodeNumber, image: image, podcastDate: date  %}
+    {% include blocks/cta_bar.liquid, cta-title: "Listen now" %}
     <main id="main" class="flex-fill">
         {% include blocks/podcast.liquid %}
     </main>


### PR DESCRIPTION
![Screenshot 2022-03-14 at 19 55 58](https://user-images.githubusercontent.com/6773151/158251159-f26741eb-7f02-47f3-aea9-2e66d4cbc9ef.png)

I added the CTA bar to the top of the podcast page - just thought it looked bare and this gives people a quick way to get to their podcast app of choice.

I looked to see if it was possible to link to the specific episodes but it's not straightforward due to a chicken & egg situation. We wouldn't be able to grab the link until the podcast is published, but we wouldn't be able to publish the podcast without the link. So just left it out for now.